### PR TITLE
Refactor server actions into data utilities

### DIFF
--- a/src/app/(home)/dashboard/DashboardClient.tsx
+++ b/src/app/(home)/dashboard/DashboardClient.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import FinancialOverview from "@/app/components/Dashboard/FinancialOverview";
+import { SpendingByCategory } from "@/app/components/Dashboard/SpendingByCategory";
+import { SpendingTrends } from "@/app/components/Dashboard/SpendingTrends";
+import SectionHeader from "@/app/components/ui/SectionHeader";
+import { useCurrency } from "@/app/hooks/useCurrency";
+import { motion } from "framer-motion";
+
+interface DashboardClientProps {
+  defaultUserCurrency: {
+    code: string;
+    symbol: string;
+  } | null;
+}
+
+const DashboardComponent = ({ defaultUserCurrency }: DashboardClientProps) => {
+  const {
+    fetchDefaultUserCurrency: {
+      data: userCurrency,
+      isLoading: defaultUserCurrencyLoading,
+    },
+  } = useCurrency(defaultUserCurrency ?? undefined);
+
+  const currency = userCurrency || defaultUserCurrency;
+
+  return (
+    <main className="container container-padding flex flex-col gap-4">
+      <SectionHeader
+        title="Dashboard"
+        description="Overview of your financial health"
+      />
+      <FinancialOverview
+        defaultCurrencySymbol={currency?.symbol || "$"}
+        currencyLoading={defaultUserCurrencyLoading}
+      />
+      <SpendingTrends
+        defaultCurrencySymbol={currency?.symbol || "$"}
+        currencyLoading={defaultUserCurrencyLoading}
+      />
+      <SpendingByCategory
+        defaultCurrencySymbol={currency?.symbol || "$"}
+        currencyLoading={defaultUserCurrencyLoading}
+        defaultCurrencyCode={currency?.code || "USD"}
+      />
+    </main>
+  );
+};
+
+export default DashboardComponent;

--- a/src/app/(home)/dashboard/page.tsx
+++ b/src/app/(home)/dashboard/page.tsx
@@ -1,41 +1,7 @@
-"use client";
+import DashboardComponent from "./DashboardClient";
+import { fetchDefaultUserCurrency } from "@/app/data/currency";
 
-import FinancialOverview from "@/app/components/Dashboard/FinancialOverview";
-import { SpendingByCategory } from "@/app/components/Dashboard/SpendingByCategory";
-import { SpendingTrends } from "@/app/components/Dashboard/SpendingTrends";
-import SectionHeader from "@/app/components/ui/SectionHeader";
-import { useCurrency } from "@/app/hooks/useCurrency";
-import { motion } from "framer-motion";
-
-const DashboardComponent = () => {
-  const {
-    fetchDefaultUserCurrency: {
-      data: defaultUserCurrency,
-      isLoading: defaultUserCurrencyLoading,
-    },
-  } = useCurrency();
-
-  return (
-    <main className="container container-padding flex flex-col gap-4">
-      <SectionHeader
-        title="Dashboard"
-        description="Overview of your financial health"
-      />
-      <FinancialOverview
-        defaultCurrencySymbol={defaultUserCurrency?.symbol || "$"}
-        currencyLoading={defaultUserCurrencyLoading}
-      />
-      <SpendingTrends
-        defaultCurrencySymbol={defaultUserCurrency?.symbol || "$"}
-        currencyLoading={defaultUserCurrencyLoading}
-      />
-      <SpendingByCategory
-        defaultCurrencySymbol={defaultUserCurrency?.symbol || "$"}
-        currencyLoading={defaultUserCurrencyLoading}
-        defaultCurrencyCode={defaultUserCurrency?.code || "USD"}
-      />
-    </main>
-  );
-};
-
-export default DashboardComponent;
+export default async function DashboardPage() {
+  const defaultUserCurrency = await fetchDefaultUserCurrency();
+  return <DashboardComponent defaultUserCurrency={defaultUserCurrency} />;
+}

--- a/src/app/actions/budget.actions.ts
+++ b/src/app/actions/budget.actions.ts
@@ -8,8 +8,12 @@ import {
 } from "@/app/schema/budget.schema";
 import { requireUser } from "@/app/utils/auth.utils";
 import { getConversionRate } from "./currency.actions";
-import { apiRequest } from "../lib/apiClient";
-import { BudgetInsights } from "../types/budget.types";
+import {
+  fetchBudgets,
+  fetchBudgetStats,
+  fetchBudgetInsights,
+} from "../data/budget";
+
 import { auth } from "@clerk/nextjs/server";
 
 type ServerBudgetData = Omit<
@@ -145,159 +149,15 @@ const deleteBudget = async (budgetId: string) => {
 };
 
 const getBudgets = async () => {
-  const user = await requireUser();
-  const userId = user.userId!;
-
-  try {
-    const budgets = await prisma.budget.findMany({
-      where: { userId },
-      include: {
-        category: true,
-        currency: true,
-        expenses: {
-          include: {
-            currency: true,
-          },
-        },
-        user: {
-          include: {
-            baseCurrency: true,
-          },
-        },
-      },
-    });
-    return budgets.map((budget) => ({
-      ...budget,
-      amount: budget.amount.toNumber(),
-      expenses: budget.expenses.map((expense) => ({
-        ...expense,
-        amount: expense.amount.toNumber(),
-      })),
-    }));
-  } catch (error) {
-    throw new Error("Failed to fetch budgets. Please try again.");
-  }
+  return fetchBudgets();
 };
 
 const getBudgetStats = async () => {
-  const user = await requireUser();
-  const userId = user.userId!;
-
-  try {
-    const budgets = await prisma.budget.findMany({
-      where: { userId },
-      include: {
-        category: true,
-        currency: true,
-        expenses: {
-          include: {
-            currency: true,
-          },
-        },
-        user: {
-          include: {
-            baseCurrency: true,
-          },
-        },
-      },
-    });
-
-    if (budgets.length === 0)
-      return {
-        budgets: [],
-        overallBudgetAmount: 0,
-        overallSpentAmount: 0,
-        overallRemainingAmount: 0,
-      };
-
-    const userDefaultCurrency = budgets[0].user.baseCurrency.code;
-
-    // Convert all amounts to numbers for easier calculation
-    const budgetsWithNumbers = budgets.map((budget) => ({
-      ...budget,
-      amount: budget.amount.toNumber(),
-      expenses: budget.expenses.map((expense) => ({
-        ...expense,
-        amount: expense.amount.toNumber(),
-      })),
-    }));
-
-    // Prepare promises for all conversions
-    let overallBudgetAmount = 0;
-    let overallSpentAmount = 0;
-    let overallRemainingAmount = 0;
-
-    for (const budget of budgetsWithNumbers) {
-      // Convert budget amount to default currency if needed
-      let budgetAmountInDefault = budget.amount;
-      if (budget.currency.code !== userDefaultCurrency) {
-        const conversionRate = await getConversionRate(
-          budget.currency.code,
-          userDefaultCurrency
-        );
-        budgetAmountInDefault = budget.amount * conversionRate;
-      }
-      overallBudgetAmount += budgetAmountInDefault;
-
-      // Sum expenses in default currency
-      let budgetSpent = 0;
-      for (const expense of budget.expenses) {
-        let expenseAmountInDefault = expense.amount;
-        if (expense.currency.code !== userDefaultCurrency) {
-          const conversionRate = await getConversionRate(
-            expense.currency.code,
-            userDefaultCurrency
-          );
-          expenseAmountInDefault = expense.amount * conversionRate;
-        }
-        budgetSpent += expenseAmountInDefault;
-      }
-      overallSpentAmount += budgetSpent;
-      overallRemainingAmount += budgetAmountInDefault - budgetSpent;
-    }
-
-    return {
-      budgets: budgetsWithNumbers,
-      overallBudgetAmount,
-      overallSpentAmount,
-      overallRemainingAmount,
-    };
-  } catch (error) {
-    throw new Error("Failed to fetch budget stats. Please try again.");
-  }
+  return fetchBudgetStats();
 };
 
 const getBudgetInsights = async (budgetId: string) => {
-  const user = await requireUser();
-  const userId = user.userId;
-
-  const token = await user.getToken();
-
-  if (!userId || !token) throw new Error("User not authenticated");
-
-  if (!budgetId) throw new Error("Budget ID is required");
-  try {
-    const budget = await prisma.budget.findUnique({
-      where: { id: budgetId, userId },
-    });
-    if (!budget) throw new Error("Budget not found");
-
-    const insights = await apiRequest<BudgetInsights>({
-      endpoint: `/insights/budget/${budgetId}`,
-      method: "GET",
-      init: {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    });
-
-    if (!insights.success) throw new Error(insights.error?.message);
-
-    return insights.data;
-  } catch (error) {
-    throw error;
-  }
+  return fetchBudgetInsights(budgetId);
 };
 
 export {

--- a/src/app/actions/category.actions.ts
+++ b/src/app/actions/category.actions.ts
@@ -1,41 +1,24 @@
 'use server';
 
-import { prisma } from "@/app/lib/client";
+import {
+  fetchExpenseCategories,
+  fetchBudgetCategories,
+} from "../data/category";
 
 export async function fetchExpenseCategoriesForSelect() {
-    try {
-        return await prisma.expenseCategory.findMany({
-            cacheStrategy: {
-                ttl: 60 * 60 * 1000, // 1 
-                swr: 60 * 60 * 1000, // 1 
-            },
-            select: {
-                id: true,
-                name: true,
-                icon: true,
-            }
-        });
-    } catch (error) {
-        console.error("Failed to fetch currencies:", error);
-        throw new Error("Could not fetch currencies");
-    }
+  try {
+    return await fetchExpenseCategories();
+  } catch (error) {
+    console.error("Failed to fetch currencies:", error);
+    throw new Error("Could not fetch currencies");
+  }
 }
 
 export async function fetchBudgetCategoriesForSelect() {
-    try {
-        return await prisma.budgetCategory.findMany({
-            cacheStrategy: {
-                ttl: 60 * 60 * 1000, // 1 
-                swr: 60 * 60 * 1000, // 1 
-            },
-            select: {
-                id: true,
-                name: true,
-                icon: true,
-            }
-        });
-    } catch (error) {
-        console.error("Failed to fetch currencies:", error);
-        throw new Error("Could not fetch currencies");
-    }
+  try {
+    return await fetchBudgetCategories();
+  } catch (error) {
+    console.error("Failed to fetch currencies:", error);
+    throw new Error("Could not fetch currencies");
+  }
 }

--- a/src/app/actions/currency.actions.ts
+++ b/src/app/actions/currency.actions.ts
@@ -1,48 +1,24 @@
 "use server";
 
-import { prisma } from "@/app/lib/client";
-import { ConversionRateResponse } from "../types/currency.types";
-import { requireUser } from "../utils/auth.utils";
+import {
+  fetchCurrencies,
+  fetchDefaultUserCurrency as fetchDefault,
+  getConversionRate as fetchRate,
+} from "../data/currency";
 
 export async function fetchCurrenciesForSelect() {
   try {
-    return await prisma.currency.findMany({
-      cacheStrategy: {
-        ttl: 60 * 60 * 1000, // 1 
-        swr: 60 * 60 * 1000, // 1 
-      },
-      select: {
-        id: true,
-        code: true,
-        name: true,
-        symbol: true,
-      },
-    });
+    return await fetchCurrencies();
   } catch (error) {
-    throw error
+    throw error;
   }
 }
 
 export async function fetchDefaultUserCurrency() {
   try {
-    const currentUser = await requireUser();
-    const user = await prisma.user.findUnique({
-      where: { id: currentUser.userId! },
-      select: {
-        baseCurrency: {
-          select: {
-            id: true,
-            code: true,
-            name: true,
-            symbol: true,
-          },
-        },
-      },
-    });
-
-    return user?.baseCurrency || null;
+    return await fetchDefault();
   } catch (error) {
-    throw error
+    throw error;
   }
 }
 
@@ -51,23 +27,8 @@ export async function getConversionRate(
   targetCurrency: string
 ) {
   try {
-    const response = await fetch(
-      `https://v6.exchangerate-api.com/v6/${process.env.EXCHANGE_RATES_API_KEY}/latest/${baseCurrency}`,
-      {
-        headers: { "Content-Type": "application/json" },
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch exchange rates from API: ${response.statusText}`
-      );
-    }
-
-    const data: ConversionRateResponse = await response.json();
-
-    return data.conversion_rates[targetCurrency];
+    return await fetchRate(baseCurrency, targetCurrency);
   } catch (error) {
-    throw error
+    throw error;
   }
 }

--- a/src/app/actions/dashboard.actions.ts
+++ b/src/app/actions/dashboard.actions.ts
@@ -1,89 +1,30 @@
 "use server";
 
-import { requireUser } from "../utils/auth.utils";
-import { apiRequest } from "../lib/apiClient";
+import {
+  fetchFinancialOverview,
+  fetchSpendingTrends,
+  fetchSpendingByCategory,
+} from "../data/dashboard";
 import {
   FetchFinancialOverviewDataParams,
   FetchSpendingTrendsDataParams,
-  SummaryData,
-  SpendingTrendData,
   FetchSpendingByCategoryDataParams,
-  CategorySpending,
 } from "../types/dashboard.types";
-import { ResponseHandler } from "../lib/ResponseHandler";
 
 export async function fetchFinancialOverviewData(
   params: FetchFinancialOverviewDataParams
 ) {
-  return ResponseHandler.execute(async () => {
-    const user = await requireUser();
-    const token = await user.getToken();
-    const { timePeriod } = params;
-
-    const summary = await apiRequest<SummaryData>({
-      method: "GET",
-      endpoint: `/dashboard/summary?timePeriod=${timePeriod}`,
-      init: {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    });
-
-    if (!summary.success || summary.data === null) {
-      throw new Error(summary.error?.message || "Data not available");
-    }
-
-    return summary.data;
-  });
+  return fetchFinancialOverview(params);
 }
 
 export async function fetchSpendingTrendsData(
   params: FetchSpendingTrendsDataParams
 ) {
-  return ResponseHandler.execute(async () => {
-    const user = await requireUser();
-    const token = await user.getToken();
-    const { timePeriod } = params;
-
-    const trends = await apiRequest<SpendingTrendData[]>({
-      method: "GET",
-      endpoint: `/dashboard/spending-trends?timePeriod=${timePeriod}`,
-      init: {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    });
-
-    if (!trends.success || trends.data === null) {
-      throw new Error(trends.error?.message || "Data not available");
-    }
-    return trends.data;
-  });
+  return fetchSpendingTrends(params);
 }
 
 export async function fetchSpendingByCategoryData(
   params: FetchSpendingByCategoryDataParams
 ) {
-  return ResponseHandler.execute(async () => {
-    const user = await requireUser();
-    const token = await user.getToken();
-    const { timePeriod } = params;
-
-    const trends = await apiRequest<CategorySpending[]>({
-      method: "GET",
-      endpoint: `/dashboard/spending-by-category?timePeriod=${timePeriod}`,
-      init: {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    });
-
-    if (!trends.success || trends.data === null) {
-      throw new Error(trends.error?.message || "Data not available");
-    }
-    return trends.data;
-  });
+  return fetchSpendingByCategory(params);
 }

--- a/src/app/actions/expense.actions.ts
+++ b/src/app/actions/expense.actions.ts
@@ -10,6 +10,7 @@ import { ResponseHandler } from "../lib/ResponseHandler";
 import ApiResponse from "../types/api-response.types";
 import { Expense, ExpenseCategory, Currency } from "@prisma/client";
 import { ExtendedExpense } from "../types/expense.types";
+import { fetchExpensesByUserId as fetchExpenses } from "../data/expenses";
 
 // Define a type for expense data returned from the create operation
 type CreatedExpense = Omit<Expense, "amount"> & { amount: number };
@@ -22,28 +23,7 @@ export type { CreatedExpense };
 const fetchExpensesByUserId = async (
   userId: string
 ): Promise<ApiResponse<ExtendedExpense[]>> => {
-  return ResponseHandler.execute<ExtendedExpense[]>(async () => {
-    const user = await requireUser();
-    if (!user || !user.userId) throw new Error("User not authenticated");
-    // Optionally, ensure the requested userId matches the authenticated user.
-    if (user.userId !== userId) {
-      throw new Error("Unauthorized access");
-    }
-
-    const expenses = await prisma.expense.findMany({
-      where: { userId },
-      orderBy: { date: "desc" },
-      include: {
-        category: true,
-        currency: true,
-      },
-    });
-
-    return expenses.map((expense) => ({
-      ...expense,
-      amount: expense.amount.toNumber(),
-    }));
-  });
+  return fetchExpenses(userId);
 };
 
 const createExpense = async (

--- a/src/app/actions/recurring-transactions.actions.ts
+++ b/src/app/actions/recurring-transactions.actions.ts
@@ -6,6 +6,7 @@ import {
   CreateRecurringTransactionSchemaType,
 } from "@/app/schema/recurring-transactions.schema";
 import { requireUser } from "@/app/utils/auth.utils";
+import { fetchRecurringTransactions } from "../data/recurringTransactions";
 
 type ServerRecurringTransactionData = Omit<
   CreateRecurringTransactionSchemaType,
@@ -168,28 +169,7 @@ const deleteRecurringTransaction = async (id: string) => {
 };
 
 const getRecurringTransactions = async () => {
-  const user = await requireUser();
-  const userId = user.userId!;
-
-  try {
-    const recurringTransactions = await prisma.financialEvent.findMany({
-      where: { userId },
-      include: {
-        budgetCategory: true,
-        currency: true,
-      },
-      orderBy: {
-        nextDueDate: 'asc',
-      },
-    });
-
-    return recurringTransactions.map((transaction) => ({
-      ...transaction,
-      amount: transaction.amount.toNumber(),
-    }));
-  } catch (error) {
-    throw new Error("Failed to fetch recurring transactions. Please try again.");
-  }
+  return fetchRecurringTransactions();
 };
 
 export {

--- a/src/app/data/budget.ts
+++ b/src/app/data/budget.ts
@@ -1,0 +1,146 @@
+import { prisma } from "@/app/lib/client";
+import { requireUser } from "@/app/utils/auth.utils";
+import { getConversionRate } from "./currency";
+import { apiRequest } from "../lib/apiClient";
+import { BudgetInsights } from "../types/budget.types";
+
+export const fetchBudgets = async () => {
+  const user = await requireUser();
+  const userId = user.userId!;
+
+  const budgets = await prisma.budget.findMany({
+    where: { userId },
+    include: {
+      category: true,
+      currency: true,
+      expenses: {
+        include: {
+          currency: true,
+        },
+      },
+      user: {
+        include: {
+          baseCurrency: true,
+        },
+      },
+    },
+  });
+
+  return budgets.map((budget) => ({
+    ...budget,
+    amount: budget.amount.toNumber(),
+    expenses: budget.expenses.map((expense) => ({
+      ...expense,
+      amount: expense.amount.toNumber(),
+    })),
+  }));
+};
+
+export const fetchBudgetStats = async () => {
+  const user = await requireUser();
+  const userId = user.userId!;
+
+  const budgets = await prisma.budget.findMany({
+    where: { userId },
+    include: {
+      category: true,
+      currency: true,
+      expenses: {
+        include: {
+          currency: true,
+        },
+      },
+      user: {
+        include: {
+          baseCurrency: true,
+        },
+      },
+    },
+  });
+
+  if (budgets.length === 0)
+    return {
+      budgets: [],
+      overallBudgetAmount: 0,
+      overallSpentAmount: 0,
+      overallRemainingAmount: 0,
+    };
+
+  const userDefaultCurrency = budgets[0].user.baseCurrency.code;
+
+  const budgetsWithNumbers = budgets.map((budget) => ({
+    ...budget,
+    amount: budget.amount.toNumber(),
+    expenses: budget.expenses.map((expense) => ({
+      ...expense,
+      amount: expense.amount.toNumber(),
+    })),
+  }));
+
+  let overallBudgetAmount = 0;
+  let overallSpentAmount = 0;
+  let overallRemainingAmount = 0;
+
+  for (const budget of budgetsWithNumbers) {
+    let budgetAmountInDefault = budget.amount;
+    if (budget.currency.code !== userDefaultCurrency) {
+      const conversionRate = await getConversionRate(
+        budget.currency.code,
+        userDefaultCurrency
+      );
+      budgetAmountInDefault = budget.amount * conversionRate;
+    }
+    overallBudgetAmount += budgetAmountInDefault;
+
+    let budgetSpent = 0;
+    for (const expense of budget.expenses) {
+      let expenseAmountInDefault = expense.amount;
+      if (expense.currency.code !== userDefaultCurrency) {
+        const conversionRate = await getConversionRate(
+          expense.currency.code,
+          userDefaultCurrency
+        );
+        expenseAmountInDefault = expense.amount * conversionRate;
+      }
+      budgetSpent += expenseAmountInDefault;
+    }
+    overallSpentAmount += budgetSpent;
+    overallRemainingAmount += budgetAmountInDefault - budgetSpent;
+  }
+
+  return {
+    budgets: budgetsWithNumbers,
+    overallBudgetAmount,
+    overallSpentAmount,
+    overallRemainingAmount,
+  };
+};
+
+export const fetchBudgetInsights = async (budgetId: string) => {
+  const user = await requireUser();
+  const userId = user.userId;
+
+  const token = await user.getToken();
+
+  if (!userId || !token) throw new Error("User not authenticated");
+  if (!budgetId) throw new Error("Budget ID is required");
+
+  const budget = await prisma.budget.findUnique({
+    where: { id: budgetId, userId },
+  });
+  if (!budget) throw new Error("Budget not found");
+
+  const insights = await apiRequest<BudgetInsights>({
+    endpoint: `/insights/budget/${budgetId}`,
+    method: "GET",
+    init: {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  });
+
+  if (!insights.success) throw new Error(insights.error?.message);
+
+  return insights.data;
+};

--- a/src/app/data/category.ts
+++ b/src/app/data/category.ts
@@ -1,0 +1,29 @@
+import { prisma } from "@/app/lib/client";
+
+export async function fetchExpenseCategories() {
+  return prisma.expenseCategory.findMany({
+    cacheStrategy: {
+      ttl: 60 * 60 * 1000,
+      swr: 60 * 60 * 1000,
+    },
+    select: {
+      id: true,
+      name: true,
+      icon: true,
+    },
+  });
+}
+
+export async function fetchBudgetCategories() {
+  return prisma.budgetCategory.findMany({
+    cacheStrategy: {
+      ttl: 60 * 60 * 1000,
+      swr: 60 * 60 * 1000,
+    },
+    select: {
+      id: true,
+      name: true,
+      icon: true,
+    },
+  });
+}

--- a/src/app/data/currency.ts
+++ b/src/app/data/currency.ts
@@ -1,0 +1,58 @@
+import { prisma } from "@/app/lib/client";
+import { ConversionRateResponse } from "../types/currency.types";
+import { requireUser } from "../utils/auth.utils";
+
+export async function fetchCurrencies() {
+  return prisma.currency.findMany({
+    cacheStrategy: {
+      ttl: 60 * 60 * 1000,
+      swr: 60 * 60 * 1000,
+    },
+    select: {
+      id: true,
+      code: true,
+      name: true,
+      symbol: true,
+    },
+  });
+}
+
+export async function fetchDefaultUserCurrency() {
+  const currentUser = await requireUser();
+  const user = await prisma.user.findUnique({
+    where: { id: currentUser.userId! },
+    select: {
+      baseCurrency: {
+        select: {
+          id: true,
+          code: true,
+          name: true,
+          symbol: true,
+        },
+      },
+    },
+  });
+
+  return user?.baseCurrency || null;
+}
+
+export async function getConversionRate(
+  baseCurrency: string,
+  targetCurrency: string
+) {
+  const response = await fetch(
+    `https://v6.exchangerate-api.com/v6/${process.env.EXCHANGE_RATES_API_KEY}/latest/${baseCurrency}`,
+    {
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch exchange rates from API: ${response.statusText}`
+    );
+  }
+
+  const data: ConversionRateResponse = await response.json();
+  return data.conversion_rates[targetCurrency];
+}

--- a/src/app/data/dashboard.ts
+++ b/src/app/data/dashboard.ts
@@ -1,0 +1,87 @@
+import { requireUser } from "../utils/auth.utils";
+import { apiRequest } from "../lib/apiClient";
+import {
+  FetchFinancialOverviewDataParams,
+  FetchSpendingTrendsDataParams,
+  SummaryData,
+  SpendingTrendData,
+  FetchSpendingByCategoryDataParams,
+  CategorySpending,
+} from "../types/dashboard.types";
+import { ResponseHandler } from "../lib/ResponseHandler";
+
+export async function fetchFinancialOverview(
+  params: FetchFinancialOverviewDataParams
+) {
+  return ResponseHandler.execute(async () => {
+    const user = await requireUser();
+    const token = await user.getToken();
+    const { timePeriod } = params;
+
+    const summary = await apiRequest<SummaryData>({
+      method: "GET",
+      endpoint: `/dashboard/summary?timePeriod=${timePeriod}`,
+      init: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    });
+
+    if (!summary.success || summary.data === null) {
+      throw new Error(summary.error?.message || "Data not available");
+    }
+
+    return summary.data;
+  });
+}
+
+export async function fetchSpendingTrends(
+  params: FetchSpendingTrendsDataParams
+) {
+  return ResponseHandler.execute(async () => {
+    const user = await requireUser();
+    const token = await user.getToken();
+    const { timePeriod } = params;
+
+    const trends = await apiRequest<SpendingTrendData[]>({
+      method: "GET",
+      endpoint: `/dashboard/spending-trends?timePeriod=${timePeriod}`,
+      init: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    });
+
+    if (!trends.success || trends.data === null) {
+      throw new Error(trends.error?.message || "Data not available");
+    }
+    return trends.data;
+  });
+}
+
+export async function fetchSpendingByCategory(
+  params: FetchSpendingByCategoryDataParams
+) {
+  return ResponseHandler.execute(async () => {
+    const user = await requireUser();
+    const token = await user.getToken();
+    const { timePeriod } = params;
+
+    const trends = await apiRequest<CategorySpending[]>({
+      method: "GET",
+      endpoint: `/dashboard/spending-by-category?timePeriod=${timePeriod}`,
+      init: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    });
+
+    if (!trends.success || trends.data === null) {
+      throw new Error(trends.error?.message || "Data not available");
+    }
+    return trends.data;
+  });
+}

--- a/src/app/data/expenses.ts
+++ b/src/app/data/expenses.ts
@@ -1,0 +1,31 @@
+import { prisma } from "@/app/lib/client";
+import { requireUser } from "../utils/auth.utils";
+import { ResponseHandler } from "../lib/ResponseHandler";
+import { ExtendedExpense } from "../types/expense.types";
+import ApiResponse from "../types/api-response.types";
+
+export const fetchExpensesByUserId = async (
+  userId: string
+): Promise<ApiResponse<ExtendedExpense[]>> => {
+  return ResponseHandler.execute<ExtendedExpense[]>(async () => {
+    const user = await requireUser();
+    if (!user || !user.userId) throw new Error("User not authenticated");
+    if (user.userId !== userId) {
+      throw new Error("Unauthorized access");
+    }
+
+    const expenses = await prisma.expense.findMany({
+      where: { userId },
+      orderBy: { date: "desc" },
+      include: {
+        category: true,
+        currency: true,
+      },
+    });
+
+    return expenses.map((expense) => ({
+      ...expense,
+      amount: expense.amount.toNumber(),
+    }));
+  });
+};

--- a/src/app/data/recurringTransactions.ts
+++ b/src/app/data/recurringTransactions.ts
@@ -1,0 +1,23 @@
+import { prisma } from "@/app/lib/client";
+import { requireUser } from "../utils/auth.utils";
+
+export const fetchRecurringTransactions = async () => {
+  const user = await requireUser();
+  const userId = user.userId!;
+
+  const recurringTransactions = await prisma.financialEvent.findMany({
+    where: { userId },
+    include: {
+      budgetCategory: true,
+      currency: true,
+    },
+    orderBy: {
+      nextDueDate: 'asc',
+    },
+  });
+
+  return recurringTransactions.map((transaction) => ({
+    ...transaction,
+    amount: transaction.amount.toNumber(),
+  }));
+};

--- a/src/app/hooks/useCurrency.ts
+++ b/src/app/hooks/useCurrency.ts
@@ -4,7 +4,9 @@ import {
 } from "@/app/actions/currency.actions";
 import { useQuery } from "@tanstack/react-query";
 
-export const useCurrency = () => {
+export const useCurrency = (
+  defaultUserCurrency?: { code: string; symbol: string } | undefined
+) => {
   return {
     query: useQuery({
       queryKey: ["currencies"],
@@ -18,9 +20,8 @@ export const useCurrency = () => {
     }),
     fetchDefaultUserCurrency: useQuery({
       queryKey: ["defaultUserCurrency"],
-      queryFn: () => {
-        return fetchDefaultUserCurrency();
-      },
+      queryFn: () => fetchDefaultUserCurrency(),
+      initialData: defaultUserCurrency,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchInterval: false,


### PR DESCRIPTION
## Summary
- extract read-only logic from server actions to `src/app/data/*`
- delegate read actions like `getBudgets` to these utilities
- update `useCurrency` hook to accept initial data
- split dashboard page into server and client parts using the new util

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449973ec848331a7a5f5bfaa197478