### PR TITLE
Add recurring transaction delete modal

### DIFF
--- a/src/app/actions/recurring-transactions.actions.ts
+++ b/src/app/actions/recurring-transactions.actions.ts
@@ -151,6 +151,8 @@ const deleteRecurringTransaction = async (id: string) => {
       where: { id, userId },
     });
 
+    revalidateTag("recurring-transactions");
+
     return { success: true };
   } catch (error) {
     throw error;

--- a/src/app/components/RecurringTransactions/DeleteRecurringTransactionModal.tsx
+++ b/src/app/components/RecurringTransactions/DeleteRecurringTransactionModal.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@heroui/modal';
+import { Button } from '@heroui/react';
+import { useAuth } from '@/app/contexts/AuthContext';
+import useRecurringTransaction from '@/app/hooks/useRecurringTransaction';
+
+interface DeleteRecurringTransactionModalProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  transactionId: string | null;
+}
+
+const DeleteRecurringTransactionModal = ({
+  isOpen,
+  onOpenChange,
+  transactionId,
+}: DeleteRecurringTransactionModalProps) => {
+  const { userId } = useAuth();
+  const {
+    delete: { mutateAsync: deleteTx, isPending },
+  } = useRecurringTransaction(userId);
+
+  const handleDelete = async () => {
+    if (!transactionId) return;
+    await deleteTx(transactionId);
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <ModalContent>
+        <ModalHeader>Confirm Deletion</ModalHeader>
+        <ModalBody>
+          <p>Are you sure you want to delete this recurring transaction?</p>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            color="secondary"
+            onPress={() => onOpenChange(false)}
+            isDisabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            color="danger"
+            onPress={handleDelete}
+            isLoading={isPending}
+            isDisabled={isPending}
+          >
+            Delete
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default DeleteRecurringTransactionModal;

--- a/src/app/components/RecurringTransactions/RecurringTransactionCard.tsx
+++ b/src/app/components/RecurringTransactions/RecurringTransactionCard.tsx
@@ -1,7 +1,7 @@
 // src/app/components/RecurringTransactions/TransactionCard.tsx
 'use client'
 
-import React from 'react'
+import React, { useState } from 'react'
 import {
   Card,
   CardHeader,
@@ -19,6 +19,7 @@ import {
   Trash,
 } from 'lucide-react'
 import { FinancialEventClient } from '@/app/types/recurring-transactions.types'
+import DeleteRecurringTransactionModal from './DeleteRecurringTransactionModal'
 
 interface TransactionCardProps {
   transaction: FinancialEventClient
@@ -40,6 +41,8 @@ export const TransactionCard: React.FC<TransactionCardProps> = ({
     description,
     isActive,
   } = transaction
+
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   // Re-hydrate the ISO string into a real Date object
   const dateObj =
@@ -72,6 +75,7 @@ export const TransactionCard: React.FC<TransactionCardProps> = ({
   ]
 
   return (
+    <>
     <Card isHoverable>
       <CardHeader className="flex items-center justify-between">
         <h3 className="text-lg font-semibold truncate">{name}</h3>
@@ -111,10 +115,17 @@ export const TransactionCard: React.FC<TransactionCardProps> = ({
           variant="flat"
           color="danger"
           startContent={<Trash size={14} />}
+          onPress={() => setDeleteOpen(true)}
         >
           Delete
         </Button>
       </CardFooter>
     </Card>
+    <DeleteRecurringTransactionModal
+      isOpen={deleteOpen}
+      onOpenChange={setDeleteOpen}
+      transactionId={id}
+    />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- support revalidation when deleting recurring transactions
- add DeleteRecurringTransactionModal component
- wire modal into RecurringTransactionCard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687abee717d88331b2a4feb743be4999